### PR TITLE
Fixed setbaudWait function

### DIFF
--- a/examples/GoldeloxBigDemo/GoldeloxBigDemo.ino
+++ b/examples/GoldeloxBigDemo/GoldeloxBigDemo.ino
@@ -20,7 +20,7 @@
 /*                                                                                           */
 /*                   Define the serial port to use here, if using software serial set it to  */
 /*                   something like SerialS.                                                 */
-  #define DisplaySerial Serial
+#define DisplaySerial Serial
 /*                                                                                           */
 /*                   To use SoftwareSerial uncomment the following and set the pins you are  */
 /*                   using correctly                                                         */
@@ -49,9 +49,6 @@
 /*                   occurs. If you want to do your own handling set Callback4D to NULL      */
 /*                   otherwise set it to the address of the error routine                    */
 /*                                                                                           */
-/* Baud rate change  Because the stream class used within the library does not support       */
-/*                   .end, or .begin the setbaudWait and SetThisBaudrate functions are       */
-/*                   coded within this demo                                                  */
 /*                                                                                           */
 /*     NB!           There is an issue with SoftwareSerial in Arduino 1.0.2 + 1.0.3 and      */
 /*                   possibly above which affects Goldelox Displays, refer here:-            */
@@ -76,73 +73,23 @@
 #include "GoldeloxBigDemo.h" 
 #include "Goldelox_Const4D.h"
 
+// Use this if using HardwareSerial or SoftwareSerial
 Goldelox_Serial_4DLib Display(&DisplaySerial);
+
+// Use this block if using a different Serial class
+//
+// void customSetBaudRate(unsigned long newRate) {
+//   DisplaySerial.flush();
+//   DisplaySerial.end();
+//   DisplaySerial.begin(newRate);
+//   delay(50) ; // Display sleeps for 100
+//   DisplaySerial.flush();  
+// }
+// Goldelox_Serial_4DLib Display(&DisplaySerial, customSetBaudRate);
+
 
 // globals for this program
 int fmediatests ;
-
-void SetThisBaudrate(int Newrate)
-{
-  int br ;
-  DisplaySerial.flush() ;
-  DisplaySerial.end() ;
-  switch(Newrate)
-  {
-    case BAUD_110    : br = 110 ;
-      break ;
-    case BAUD_300    : br = 300 ;
-      break ;
-    case BAUD_600    : br = 600 ;
-      break ;
-    case BAUD_1200   : br = 1200 ;
-      break ;
-    case BAUD_2400   : br = 2400 ;
-      break ;
-    case BAUD_4800   : br = 4800 ;
-      break ;
-    case BAUD_9600   : br = 9600 ;
-      break ;
-    case BAUD_14400  : br = 14400 ;
-      break ;
-    case BAUD_19200  : br = 19200 ;
-      break ;
-    case BAUD_31250  : br = 31250 ;
-      break ;
-    case BAUD_38400  : br = 38400 ;
-      break ;
-    case BAUD_56000  : br = 56000 ;
-      break ;
-    case BAUD_57600  : br = 57600 ;
-      break ;
-    case BAUD_115200 : br = 115200 ;
-      break ;
-    case BAUD_128000 : br = 133928 ; // actual rate is not 128000 ;
-      break ;
-    case BAUD_256000 : br = 281250 ; // actual rate is not  256000 ;
-      break ;
-    case BAUD_300000 : br = 312500 ; // actual rate is not  300000 ;
-      break ;
-    case BAUD_375000 : br = 401785 ; // actual rate is not  375000 ;
-      break ;
-    case BAUD_500000 : br = 562500 ; // actual rate is not  500000 ;
-      break ;
-    case BAUD_600000 : br = 703125 ; // actual rate is not  600000 ;
-      break ;
-  }
-  DisplaySerial.begin(br) ;
-  delay(50) ; // Display sleeps for 100
-  DisplaySerial.flush() ;
-}
-
-void setbaudWait(word  Newrate)
-{
-  DisplaySerial.print((char)(F_setbaudWait >> 8));
-  DisplaySerial.print((char)(F_setbaudWait));
-  DisplaySerial.print((char)(Newrate >> 8));
-  DisplaySerial.print((char)(Newrate));
-  SetThisBaudrate(Newrate); // change this systems baud rate to match new display rate, ACK is 100ms away
-  Display.GetAck() ;
-}
 
 int trymount(void)
 {
@@ -571,9 +518,9 @@ void loop()
 
 //Display.BeeP(40,2000) ;
   Display.gfx_Cls() ;
-  setbaudWait(BAUD_19200) ;
+  Display.setbaudWait(BAUD_19200) ;
   Display.putstr("Hi at 19200\n") ;
-  setbaudWait(BAUD_9600) ;
+  Display.setbaudWait(BAUD_9600) ;
   Display.putstr("Back to 9600\n") ;
   delay(5000);
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Goldelox-Serial-Arduino-Library
-version=1.0.2
+version=1.0.3
 author=4D Systems
 maintainer=4D Systems
 sentence=Provides library access to communicate with the 4D Systems Goldelox processor, when configured in Serial/SPE mode

--- a/src/Goldelox_Serial_4DLib.cpp
+++ b/src/Goldelox_Serial_4DLib.cpp
@@ -11,44 +11,28 @@
 #endif
 
 Goldelox_Serial_4DLib::Goldelox_Serial_4DLib(Stream * virtualPort, void (*setBaudRateHndl)(unsigned long)) { 
-    _virtualPort = virtualPort; 
-    setBaudRateExternal = setBaudRateHndl;
-    setBaudRateInternal = &Goldelox_Serial_4DLib::exSetBaudRateHndl;
-    unknownSerial = true;
-#if !defined(ARDUINO_ARCH_SAMD) || (ARDUINO_ARCH_SAM)
-	//Only done for non-SAMD/SAM architectures
-	_virtualPort->flush();
-#endif
+  _virtualPort = virtualPort; 
+  setBaudRateExternal = setBaudRateHndl;
+  setBaudRateInternal = &Goldelox_Serial_4DLib::exSetBaudRateHndl;
+  unknownSerial = true;
 }
 
 Goldelox_Serial_4DLib::Goldelox_Serial_4DLib(HardwareSerial * serial) { 
-    _virtualPort = (Stream *)serial; 
-    setBaudRateInternal = &Goldelox_Serial_4DLib::hwSetBaudRateHndl;
-#if !defined(ARDUINO_ARCH_SAMD) || (ARDUINO_ARCH_SAM)
-	//Only done for non-SAMD/SAM architectures
-	_virtualPort->flush();
-#endif
+  _virtualPort = (Stream *)serial; 
+  setBaudRateInternal = &Goldelox_Serial_4DLib::hwSetBaudRateHndl;
 }
 
 #ifdef SoftwareSerial_h		
 Goldelox_Serial_4DLib::Goldelox_Serial_4DLib(SoftwareSerial * serial) { 
-    _virtualPort = (Stream *)serial; 
-    setBaudRateInternal = &Goldelox_Serial_4DLib::swSetBaudRateHndl;
-#if !defined(ARDUINO_ARCH_SAMD) || (ARDUINO_ARCH_SAM)
-	//Only done for non-SAMD/SAM architectures
-	_virtualPort->flush();
-#endif
+  _virtualPort = (Stream *)serial; 
+  setBaudRateInternal = &Goldelox_Serial_4DLib::swSetBaudRateHndl;
 }
 #endif
 
 #ifdef AltSoftSerial_h
 Goldelox_Serial_4DLib::Goldelox_Serial_4DLib(AltSoftSerial * serial) { 
-    _virtualPort = (Stream *)serial; 
-    setBaudRateInternal = &Goldelox_Serial_4DLib::alSetBaudRateHndl;
-#if !defined(ARDUINO_ARCH_SAMD) || (ARDUINO_ARCH_SAM)
-	//Only done for non-SAMD/SAM architectures
-	_virtualPort->flush();
-#endif
+  _virtualPort = (Stream *)serial; 
+  setBaudRateInternal = &Goldelox_Serial_4DLib::alSetBaudRateHndl;
 }
 #endif
 

--- a/src/Goldelox_Serial_4DLib.cpp
+++ b/src/Goldelox_Serial_4DLib.cpp
@@ -10,13 +10,47 @@
 	#include "WProgram.h" // for Arduino 23
 #endif
 
-Goldelox_Serial_4DLib::Goldelox_Serial_4DLib(Stream * virtualPort) { 
+Goldelox_Serial_4DLib::Goldelox_Serial_4DLib(Stream * virtualPort, void (*setBaudRateHndl)(unsigned long)) { 
     _virtualPort = virtualPort; 
+    setBaudRateExternal = setBaudRateHndl;
+    setBaudRateInternal = &Goldelox_Serial_4DLib::exSetBaudRateHndl;
+    unknownSerial = true;
 #if !defined(ARDUINO_ARCH_SAMD) || (ARDUINO_ARCH_SAM)
 	//Only done for non-SAMD/SAM architectures
 	_virtualPort->flush();
 #endif
 }
+
+Goldelox_Serial_4DLib::Goldelox_Serial_4DLib(HardwareSerial * serial) { 
+    _virtualPort = (Stream *)serial; 
+    setBaudRateInternal = &Goldelox_Serial_4DLib::hwSetBaudRateHndl;
+#if !defined(ARDUINO_ARCH_SAMD) || (ARDUINO_ARCH_SAM)
+	//Only done for non-SAMD/SAM architectures
+	_virtualPort->flush();
+#endif
+}
+
+#ifdef SoftwareSerial_h		
+Goldelox_Serial_4DLib::Goldelox_Serial_4DLib(SoftwareSerial * serial) { 
+    _virtualPort = (Stream *)serial; 
+    setBaudRateInternal = &Goldelox_Serial_4DLib::swSetBaudRateHndl;
+#if !defined(ARDUINO_ARCH_SAMD) || (ARDUINO_ARCH_SAM)
+	//Only done for non-SAMD/SAM architectures
+	_virtualPort->flush();
+#endif
+}
+#endif
+
+#ifdef AltSoftSerial_h
+Goldelox_Serial_4DLib::Goldelox_Serial_4DLib(AltSoftSerial * serial) { 
+    _virtualPort = (Stream *)serial; 
+    setBaudRateInternal = &Goldelox_Serial_4DLib::alSetBaudRateHndl;
+#if !defined(ARDUINO_ARCH_SAMD) || (ARDUINO_ARCH_SAM)
+	//Only done for non-SAMD/SAM architectures
+	_virtualPort->flush();
+#endif
+}
+#endif
 
 //*********************************************************************************************//
 //**********************************Intrinsic 4D Routines**************************************//
@@ -197,68 +231,6 @@ word Goldelox_Serial_4DLib::GetAckResStr(char * OutStr)
 	Result = GetWord() ;
 	getString(OutStr, Result) ;
 	return Result ;
-}
-/*
-word Goldelox_Serial_4DLib::GetAckResData(t4DByteArray OutData, word size)
-{
-	int Result ;
-	GetAck() ;
-	Result = GetWord() ;
-	getbytes(OutData, size) ;
-	return Result ;
-}
-*/
-void Goldelox_Serial_4DLib::SetThisBaudrate(int Newrate)
-{
-  int br ;
-  _virtualPort->flush() ;
-//  _virtualPort->end() ;
-  switch(Newrate)
-  {
- /*   case BAUD_110    : br = 110 ;
-      break ;
-    case BAUD_300    : br = 300 ;
-      break ;
-    case BAUD_600    : br = 600 ;
-      break ;
-    case BAUD_1200   : br = 1200 ;
-      break ;
-    case BAUD_2400   : br = 2400 ;
-      break ;
-    case BAUD_4800   : br = 4800 ;
-      break ;*/
-    case BAUD_9600   : br = 9600 ;
-      break ;
-//   case BAUD_14400  : br = 14400 ;
-//      break ;
-    case BAUD_19200  : br = 19200 ;
-      break ;
- /*   case BAUD_31250  : br = 31250 ;
-      break ;
-    case BAUD_38400  : br = 38400 ;
-      break ;
-    case BAUD_56000  : br = 56000 ;
-      break ;
-    case BAUD_57600  : br = 57600 ;
-      break ;
-    case BAUD_115200 : br = 115200 ;
-      break ;
-    case BAUD_128000 : br = 133928 ; // actual rate is not 128000 ;
-      break ;
-    case BAUD_256000 : br = 281250 ; // actual rate is not  256000 ;
-      break ;
-    case BAUD_300000 : br = 312500 ; // actual rate is not  300000 ;
-      break ;
-    case BAUD_375000 : br = 401785 ; // actual rate is not  375000 ;
-      break ;
-    case BAUD_500000 : br = 562500 ; // actual rate is not  500000 ;
-      break ;
-    case BAUD_600000 : br = 703125 ; // actual rate is not  600000 ;
-      break ;*/
-  }
-//  _virtualPort->begin(br) ;
-  delay(50) ; // Display sleeps for 100
-  _virtualPort->flush() ;
 }
 
 //*********************************************************************************************//
@@ -1141,16 +1113,6 @@ void Goldelox_Serial_4DLib::blitComtoDisplay(word  X, word  Y, word  Width, word
   GetAck() ;
 }
 
-void Goldelox_Serial_4DLib::setbaudWait(word  Newrate)
-{
-  _virtualPort->print((char)(F_setbaudWait >> 8)) ;
-  _virtualPort->print((char)(F_setbaudWait)) ;
-  _virtualPort->print((char)(Newrate >> 8)) ;
-  _virtualPort->print((char)(Newrate)) ;
-  SetThisBaudrate(Newrate) ; // change this systems baud rate to match new display rate, ACK is 100ms away
-  GetAck() ;
-}
-
 word Goldelox_Serial_4DLib::peekW(word  Address)
 {
   _virtualPort->print((char)(F_peekW >> 8)) ;
@@ -1224,3 +1186,121 @@ void Goldelox_Serial_4DLib::SSMode(word  Parm)
   _virtualPort->print((char)(Parm)) ;
   GetAck() ;
 }
+
+unsigned long Goldelox_Serial_4DLib::GetBaudRate(word Newrate)
+{
+  unsigned long br ;
+  switch(Newrate)
+  {
+    case BAUD_110:
+      br = 110l ;
+      break ;
+    case BAUD_300:
+      br = 300l ;
+      break ;
+    case BAUD_600:
+      br = 600l ;
+      break ;
+    case BAUD_1200:
+      br = 1200l ;
+      break ;
+    case BAUD_2400:
+      br = 2400l ;
+      break ;
+    case BAUD_4800:
+      br = 4800l ;
+      break ;
+    case BAUD_9600:
+      br = 9600l ;
+      break ;
+    case BAUD_14400:
+      br = 14400l ;
+     break ;
+    case BAUD_19200:
+      br = 19200l ;
+      break ;
+    case BAUD_31250:
+      br = 31250l ;
+      break ;
+    case BAUD_38400:
+      br = 38400l ;
+      break ;
+    case BAUD_56000:
+      br = 56000l ;
+      break ;
+    case BAUD_57600:
+      br = 57600l ;
+      break ;
+    case BAUD_115200:
+      br = 115200l ;
+      break ;
+    case BAUD_128000:
+      br = 133928l ; // actual rate is not 128000 ;
+      break ;
+    case BAUD_256000:
+      br = 281250l ; // actual rate is not  256000 ;
+      break ;
+    case BAUD_300000:
+      br = 312500l ; // actual rate is not  300000 ;
+      break ;
+    case BAUD_375000:
+      br = 401785l ; // actual rate is not  375000 ;
+      break ;
+    case BAUD_500000:
+      br = 562500l ; // actual rate is not  500000 ;
+      break ;
+    case BAUD_600000:
+      br = 703125l ; // actual rate is not  600000 ;
+      break ;
+    default:
+      br = 0;
+      break;
+  }
+  return br;
+}
+
+bool Goldelox_Serial_4DLib::setbaudWait(word Newrate)
+{
+  if (unknownSerial && (setBaudRateExternal == NULL)) return false;
+  unsigned long baudrate = GetBaudRate(Newrate);
+  if (baudrate == 0) return false;
+  _virtualPort->print((char)(F_setbaudWait >> 8));
+  _virtualPort->print((char)(F_setbaudWait));
+  _virtualPort->print((char)(Newrate >> 8));
+  _virtualPort->print((char)(Newrate));
+  (this->*setBaudRateInternal)(baudrate); // change this systems baud rate to match new display rate, ACK is 100ms away
+  GetAck() ;
+  return true;
+}
+
+void Goldelox_Serial_4DLib::exSetBaudRateHndl(unsigned long newRate) {
+  setBaudRateExternal(newRate);
+}
+
+void Goldelox_Serial_4DLib::hwSetBaudRateHndl(unsigned long newRate) {
+  ((HardwareSerial *)_virtualPort)->flush();
+  ((HardwareSerial *)_virtualPort)->end();
+  ((HardwareSerial *)_virtualPort)->begin(newRate);
+  delay(50) ; // Display sleeps for 100
+  ((HardwareSerial *)_virtualPort)->flush();
+}
+
+#ifdef SoftwareSerial_h
+void Goldelox_Serial_4DLib::swSetBaudRateHndl(unsigned long newRate) {
+  ((SoftwareSerial *)_virtualPort)->flush();
+  ((SoftwareSerial *)_virtualPort)->end();
+  ((SoftwareSerial *)_virtualPort)->begin(newRate);
+  delay(50) ; // Display sleeps for 100
+  ((SoftwareSerial *)_virtualPort)->flush();  
+}
+#endif
+
+#ifdef AltSoftSerial_h
+void Goldelox_Serial_4DLib::alSetBaudRateHndl(unsigned long newRate) {
+  ((AltSoftSerial *)_virtualPort)->flush();
+  ((AltSoftSerial *)_virtualPort)->end();
+  ((AltSoftSerial *)_virtualPort)->begin(newRate);
+  delay(50) ; // Display sleeps for 100
+  ((AltSoftSerial *)_virtualPort)->flush();  
+}
+#endif

--- a/src/Goldelox_Serial_4DLib.h
+++ b/src/Goldelox_Serial_4DLib.h
@@ -22,6 +22,11 @@
 
 #include <string.h>
 
+#ifdef AVR
+#include <SoftwareSerial.h> // uncomment this line to add direct support for SoftwareSerial
+// #include <AltSoftSerial.h> // uncomment this line to add direct support for AltSoftSerial (Note: AltSoftSerial needs to be installed in Arduino IDE)
+#endif
+
 #define DEC 10
 #define HEX 16
 #define OCT 8
@@ -32,7 +37,14 @@ typedef void (*Tcallback4D)(int, unsigned char);
 class Goldelox_Serial_4DLib
 {
 	public:
-		Goldelox_Serial_4DLib(Stream * virtualPort);
+		Goldelox_Serial_4DLib(Stream * virtualPort, void (*setBaudRateHndl)(unsigned long) = NULL);
+		Goldelox_Serial_4DLib(HardwareSerial * serial);
+#ifdef SoftwareSerial_h		
+		Goldelox_Serial_4DLib(SoftwareSerial * serial);
+#endif
+#ifdef AltSoftSerial_h
+	    Goldelox_Serial_4DLib(AltSoftSerial * serial);
+#endif
 		Tcallback4D Callback4D ;
 		
 		//Compound 4D Routines
@@ -95,7 +107,7 @@ class Goldelox_Serial_4DLib
 
 		//------------------------------------------------/
 
-		void setbaudWait(word  Newrate) ;
+		bool setbaudWait(word Newrate) ;
 		void SSMode(word  Parm) ;
 		void SSSpeed(word  Speed) ;
 		void SSTimeout(word  Seconds) ;
@@ -146,7 +158,20 @@ class Goldelox_Serial_4DLib
 									// or indeterminate (eg file_exec, file_run, file_callFunction) commands
 		
 	private:
-                Stream * _virtualPort;
+		bool unknownSerial = false;
+		Stream * _virtualPort;
+		unsigned long GetBaudRate(word Newrate);
+		void (*setBaudRateExternal)(unsigned long newRate);
+		void (Goldelox_Serial_4DLib::*setBaudRateInternal)(unsigned long newRate);
+
+		void exSetBaudRateHndl(unsigned long newRate);
+		void hwSetBaudRateHndl(unsigned long newRate);
+#ifdef SoftwareSerial_h
+		void swSetBaudRateHndl(unsigned long newRate);
+#endif
+#ifdef AltSoftSerial_h
+		void alSetBaudRateHndl(unsigned long newRate);
+#endif	
 
 		//Intrinsic 4D Routines
 		void WriteChars(char * charsout);
@@ -160,7 +185,6 @@ class Goldelox_Serial_4DLib
 		void GetAck2Words(word * word1, word * word2);
 		word GetAckResStr(char * OutStr);
 	//	word GetAckResData(t4DByteArray OutData, word size);
-		void SetThisBaudrate(int Newrate);
 		
 		void printNumber(unsigned long, uint8_t);
 		void printFloat(double number, uint8_t digits);


### PR DESCRIPTION
This update adds additional constructors that helps identify what type of Serial is being used. This lets the library correctly perform `end()` and `begin()` for `setbaudWait()`

Changed:
- `Goldelox_Serial_4DLib(Stream * virtualPort` to
`Goldelox_Serial_4DLib(Stream * virtualPort, void (*setBaudRateHndl)(unsigned long) = NULL)`

Added:
- `Goldelox_Serial_4DLib(HardwareSerial * serial);`
- `Goldelox_Serial_4DLib(SoftwareSerial * serial);`